### PR TITLE
fix error because currRe couldn't be found

### DIFF
--- a/MergeCalendarsTogether.gs
+++ b/MergeCalendarsTogether.gs
@@ -60,6 +60,7 @@ function IsOnIgnoreList(event) {
   for (const currRe of IGNORE_LIST_REGEXES) {
     const isMatch = new RegExp(currRe).test(event.summary)
     if (isMatch) {
+      console.log(`Ignoring event "${event.summary}" that matches regex "${currRe}"`)
       return true
     }
   }
@@ -138,7 +139,6 @@ function SortEvents(calendarId, events) {
         // only check ignores for the "primary". We need them to still end up in the
         // "merged" so they'll be cleaned up when new ignores are added.
         if (IsOnIgnoreList(event)) {
-          console.log(`Ignoring event "${event.summary}" that matches regex "${currRe}"`)
           return
         }
         const eventDateTime = primary[realStart] || [];


### PR DESCRIPTION
Fixing
```
Error  ReferenceError: currRe is not defined
    at [unknown function](Code:139:80)
    at SortEvents(Code:119:18)
    at [unknown function](Code:179:20)
    at RetrieveCalendars(Code:157:22)
    at MergeCalendarsTogether(Code:44:21)
```

I'm guessing you aren't currently using the ignore list feature :thinking: 