### PR TITLE
Create an option for syncing meeting responseStatus

### DIFF
--- a/MergeCalendarsTogether.gs
+++ b/MergeCalendarsTogether.gs
@@ -290,10 +290,6 @@ function RetrieveCalendars(startTime, endTime) {
       nextPage = result.nextPageToken;
     } while(nextPage);
     log.info(`Found ${items.length} items for ${calendarId}`)
-    const isNoEventsFound = !items.length
-    if (isNoEventsFound) {
-      return;
-    }
 
     calendars.push(SortEvents(calendarId, items));
   });

--- a/MergeCalendarsTogether.gs
+++ b/MergeCalendarsTogether.gs
@@ -40,6 +40,7 @@ const OBFUSCATE_LIST_REGEXES = [
 const USER_INCLUDE_DESC = false;
 
 // should we copy the original attendance status from the primary calendar?
+// If true, we'll keep your declined/pending status instead of marking you busy.
 const USER_COPY_SELF_ATTENDANCE_STATUS = false;
 
 // ----------------------------------------------------------------------------

--- a/MergeCalendarsTogether.gs
+++ b/MergeCalendarsTogether.gs
@@ -172,7 +172,7 @@ function ExistsInDestination(destination, originEvent) {
       return mergedEvent.summary === GetMergeSummary(originEvent) &&
         mergedEvent.location === originEvent.location &&
         !isDescWrong(mergedEvent) && // sorry for the double negative :'(
-        AttendeeSelfStatusMatches(mergedEvent, originEvent)
+        AttendeeSelfStatusMatches(originEvent, mergedEvent)
     })
 }
 
@@ -326,13 +326,13 @@ function MergeCalendars (calendars) {
               end: originEvent.end,
               attendees: GetAttendeeSelf(originEvent, destination),
             }
-            log.debug('Pre Event Update Body: ', body)
-            calendarRequests.push({
+            log.debug(`Pre-event update body for destination:  ${destination.calendarId} :: ${body}`)
+            calendarRequests.push(JSON.parse(JSON.stringify({
               method: 'POST',
               endpoint: `${ENDPOINT_BASE}/${destination.calendarId}/events`,
               summary: body.summary, // Only used in debugging statements
               requestBody: body,
-            });
+            })));
           }
           payloadSets[destination.calendarId] = calendarRequests;
         });
@@ -370,9 +370,9 @@ function MergeCalendars (calendars) {
       if (!result.getResponseCode || result.getResponseCode() !== 200) {
         log.info(result)
       } else {
-        log.debug('BatchRequest result: ', result.toString(), '; ', result.getResponseCode() )
+        log.debug('RESULT: ', result.toString(), '; ', result.getResponseCode() )
+        log.info(`${calendarRequests.length} events modified for ${calendarId}:`);
       }
-      log.info(`${calendarRequests.length} events modified for ${calendarId}:`);
     } else {
       log.debug(`${calendarRequests.length} events would have been modified for ${calendarId}:`);
     }

--- a/MergeCalendarsTogether.gs
+++ b/MergeCalendarsTogether.gs
@@ -161,7 +161,8 @@ function ExistsInOrigin(origin, mergedEvent) {
   return !!origin.primary[realStart]
     ?.some(originEvent => {
       return mergedEvent.summary === GetMergeSummary(originEvent) &&
-        mergedEvent.location === originEvent.location
+        mergedEvent.location === originEvent.location &&
+        AttendeeSelfStatusMatches(originEvent, mergedEvent)
     })
 }
 

--- a/test.js
+++ b/test.js
@@ -309,7 +309,7 @@ it('should return false when origin and merged have mismatched Attendee status',
       self: true,
       responseStatus: 'accepted'
     }]}
-  const mergedEvent = { attendees:
+  const mergedEvent = { attendees:q
     [{
       email: 'user.email@turducken.com',
       self: true,
@@ -322,6 +322,7 @@ it('should return false when origin and merged have mismatched Attendee status',
 })
 
 it('should return self attendee with updated email', () => {
+  objectUnderTest.TEST_COPY_SELF_ATTENDANCE_STATUS = true;
   const originEvent = { attendees:
     [{
       email: 'user.email@cheeseburger.com',

--- a/test.js
+++ b/test.js
@@ -284,6 +284,62 @@ it('should NOT match a summary to obfuscate', () => {
   return result
 })
 
+it('should return true when COPY_SELF_ATTENDANCE_STATUS is disabled', () => {
+  // attendees definitely don't match; would find diff if enabled
+  const originEvent = { attendees: {
+    self: true
+  }}
+  const mergedEvent = {}
+  return true === objectUnderTest.AttendeeSelfStatusMatches(originEvent, mergedEvent)
+})
+
+it('should return [] when COPY_SELF_ATTENDANCE_STATUS is disabled', () => {
+  const originEvent = {}
+  const destination = {}
+  const res = objectUnderTest.GetAttendeeSelf(originEvent, destination)
+  return (Array.isArray(res) && res.length === 0)
+})
+
+it('should return false when origin and merged have mismatched Attendee status', () => {
+  objectUnderTest.TEST_COPY_SELF_ATTENDANCE_STATUS = true;
+  // attendees definitely don't match; would find diff if enabled
+  const originEvent =  { attendees:
+    [{
+      email: 'user.email@cheeseburger.com',
+      self: true,
+      responseStatus: 'accepted'
+    }]}
+  const mergedEvent = { attendees:
+    [{
+      email: 'user.email@turducken.com',
+      self: true,
+      responseStatus: 'needsAction'
+    }]}
+  const res1 = (false === objectUnderTest.AttendeeSelfStatusMatches(originEvent, mergedEvent))
+  const res2 = (false === objectUnderTest.AttendeeSelfStatusMatches({attendees: []}, mergedEvent))
+
+  return res1 & res2
+})
+
+it('should return self attendee with updated email', () => {
+  const originEvent = { attendees:
+    [{
+      email: 'user.email@cheeseburger.com',
+      self: true,
+      responseStatus: 'needsAction'
+    },
+    {
+      email: 'a.real.jerk@cheeseburger.com',
+      responseStatus: 'accepted'
+    }]}
+  const destination = {calendarId: 'another.email.address@whatever.com'}
+  const res = objectUnderTest.GetAttendeeSelf(originEvent, destination)
+  return (Array.isArray(res) &&
+    res[0].email === destination.calendarId &&
+    res[0].self === originEvent.attendees[0].self &&
+    res[0].responseStatus === originEvent.attendees[0].responseStatus);
+})
+
 function it(msg, fn) {
   try {
     if (fn()) {

--- a/test.js
+++ b/test.js
@@ -302,7 +302,6 @@ it('should return [] when COPY_SELF_ATTENDANCE_STATUS is disabled', () => {
 
 it('should return false when origin and merged have mismatched Attendee status', () => {
   objectUnderTest.TEST_COPY_SELF_ATTENDANCE_STATUS = true;
-  // attendees definitely don't match; would find diff if enabled
   const originEvent =  { attendees:
     [{
       email: 'user.email@cheeseburger.com',

--- a/test.js
+++ b/test.js
@@ -308,7 +308,7 @@ it('should return false when origin and merged have mismatched Attendee status',
       self: true,
       responseStatus: 'accepted'
     }]}
-  const mergedEvent = { attendees:q
+  const mergedEvent = { attendees:
     [{
       email: 'user.email@turducken.com',
       self: true,


### PR DESCRIPTION
This allows a user to sync their responseStatus across calendars so that meeting time is not blocked on remote calendar if it's not blocked on origin calendar.

This preserves only the responseStatus for the user who the calendar belongs to (self === true).