### PR TITLE
Disallow parallel execution

### DIFF
--- a/MergeCalendarsTogether.gs
+++ b/MergeCalendarsTogether.gs
@@ -50,8 +50,11 @@ const LOC_NOT_COPIED_MSG = '(location not copied)'
 // listed as first function so it's the default to run in the web UI
 function MergeCalendarsTogether() {
   const dates = GetStartEndDates();
+  var lock = LockService.getScriptLock();
+  lock.tryLock(60000);
   const calendars = RetrieveCalendars(dates[0], dates[1]);
   MergeCalendars(calendars);
+  lock.releaseLock();
 }
 
 function DeleteAllMerged () {


### PR DESCRIPTION
Events created by the script mid-run re-trigger the script. This can lead to two instances of the script running simultaneously, both attempting to create Merged Events on a destination calendar (because both **queries** are done before the **creation** call can be completed).

This change will not _prevent_ these events from triggering, but they will allow them to be delayed until all changes from the original execution are completed. In most cases, the resulting flow will be what the user expects - the subsequent executions of the script will result in no changes.

Original fix submitted in PR #11 by @LukasKaufmannRelaxdays - THANK YOU!